### PR TITLE
Add a default implementation for passkey name, based on Devise auth keys

### DIFF
--- a/lib/devise/passkeys/controllers/passkeys_controller_concern.rb
+++ b/lib/devise/passkeys/controllers/passkeys_controller_concern.rb
@@ -90,7 +90,7 @@ module Devise
         end
 
         def user_details_for_registration
-          { id: resource.webauthn_id, name: resource.send(resource_class.authentication_keys.first) }
+          { id: resource.webauthn_id, name: resource.default_passkey_name }
         end
 
         def verify_credential_integrity

--- a/lib/devise/passkeys/model.rb
+++ b/lib/devise/passkeys/model.rb
@@ -13,6 +13,10 @@ module Devise
       # @param passkey [String] the passkey that was used for authentication
       def after_passkey_authentication(passkey:); end
 
+      # By default, the passkey name will be the first Devise authentication key, to keep
+      # backward compatibility, but allow users to override this behavior
+      # @example
+      #  :email
       def default_passkey_name
         self.class.authentication_keys.first
       end

--- a/lib/devise/passkeys/model.rb
+++ b/lib/devise/passkeys/model.rb
@@ -12,6 +12,10 @@ module Devise
       # (such as notifying the user of a new login).
       # @param passkey [String] the passkey that was used for authentication
       def after_passkey_authentication(passkey:); end
+
+      def default_passkey_name
+        self.class.authentication_keys.first
+      end
     end
   end
 end

--- a/test/devise/test_passkey_issuer.rb
+++ b/test/devise/test_passkey_issuer.rb
@@ -9,6 +9,8 @@ class Devise::TestPasskeyIssuer < ActiveSupport::TestCase
   test "create_and_return_passkey" do
     user = User.create!(email: "test@test.com")
 
+    assert_equal :email, user.default_passkey_name
+
     relying_party = example_relying_party
     client = fake_client(origin: relying_party.origin)
     credential = create_raw_credential(credential_hash: client.create, relying_party: relying_party)


### PR DESCRIPTION
### In this PR
- [x] Address https://github.com/ruby-passkeys/devise-passkeys/pull/50#issuecomment-1704335778
- [x] Added test for the default implementation